### PR TITLE
Implement basic backend and TikTok style tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "yes | pnpm install && vite",
     "build": "yes | pnpm install && rm -rf node_modules/.vite-temp && tsc -b && vite build",
     "lint": "yes | pnpm install && eslint .",
-    "preview": "yes | pnpm install && vite preview"
+    "preview": "yes | pnpm install && vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -42,6 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
+    "express": "^4.19.2",
     "crypto-js": "^4.2.0",
     "date-fns": "^3.0.0",
     "embla-carousel-react": "^8.5.2",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,121 @@
+const express = require('express');
+const fs = require('fs/promises');
+const path = require('path');
+
+const app = express();
+app.use(express.json());
+
+const dataDir = path.join(__dirname, 'public', 'data');
+const coursesFile = path.join(dataDir, 'courses.json');
+const videosFile = path.join(dataDir, 'videos.json');
+
+async function readJson(file) {
+  const content = await fs.readFile(file, 'utf-8');
+  return JSON.parse(content);
+}
+
+async function writeJson(file, data) {
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+}
+
+// Courses API
+app.get('/api/courses', async (req, res) => {
+  try {
+    const courses = await readJson(coursesFile);
+    res.json(courses);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load courses' });
+  }
+});
+
+app.post('/api/courses', async (req, res) => {
+  try {
+    const courses = await readJson(coursesFile);
+    const newCourse = { id: Date.now(), ...req.body };
+    courses.push(newCourse);
+    await writeJson(coursesFile, courses);
+    res.json(newCourse);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save course' });
+  }
+});
+
+app.put('/api/courses/:id', async (req, res) => {
+  try {
+    const courses = await readJson(coursesFile);
+    const idx = courses.findIndex(c => c.id === Number(req.params.id));
+    if (idx === -1) return res.status(404).end();
+    courses[idx] = { ...courses[idx], ...req.body, id: courses[idx].id };
+    await writeJson(coursesFile, courses);
+    res.json(courses[idx]);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update course' });
+  }
+});
+
+app.delete('/api/courses/:id', async (req, res) => {
+  try {
+    const courses = await readJson(coursesFile);
+    const idx = courses.findIndex(c => c.id === Number(req.params.id));
+    if (idx === -1) return res.status(404).end();
+    const removed = courses.splice(idx, 1)[0];
+    await writeJson(coursesFile, courses);
+    res.json(removed);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete course' });
+  }
+});
+
+// Videos API
+app.get('/api/videos', async (req, res) => {
+  try {
+    const videos = await readJson(videosFile);
+    res.json(videos);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load videos' });
+  }
+});
+
+app.post('/api/videos', async (req, res) => {
+  try {
+    const videos = await readJson(videosFile);
+    const newVideo = { id: Date.now(), ...req.body };
+    videos.push(newVideo);
+    await writeJson(videosFile, videos);
+    res.json(newVideo);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save video' });
+  }
+});
+
+app.put('/api/videos/:id', async (req, res) => {
+  try {
+    const videos = await readJson(videosFile);
+    const idx = videos.findIndex(v => v.id === Number(req.params.id));
+    if (idx === -1) return res.status(404).end();
+    videos[idx] = { ...videos[idx], ...req.body, id: videos[idx].id };
+    await writeJson(videosFile, videos);
+    res.json(videos[idx]);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update video' });
+  }
+});
+
+app.delete('/api/videos/:id', async (req, res) => {
+  try {
+    const videos = await readJson(videosFile);
+    const idx = videos.findIndex(v => v.id === Number(req.params.id));
+    if (idx === -1) return res.status(404).end();
+    const removed = videos.splice(idx, 1)[0];
+    await writeJson(videosFile, videos);
+    res.json(removed);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete video' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -61,18 +61,32 @@ const AdminPage: React.FC = () => {
     setEditingVideo(null);
   };
 
-  const handleSaveCourse = () => {
-    // 这里应该调用API保存课程数据
-    console.log('保存课程:', courseForm);
+  const handleSaveCourse = async () => {
+    const method = editingCourse ? 'PUT' : 'POST';
+    const url = editingCourse
+      ? `/api/courses/${editingCourse.id}`
+      : '/api/courses';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(courseForm),
+    });
     setShowCourseForm(false);
     resetCourseForm();
+    window.location.reload();
   };
 
-  const handleSaveVideo = () => {
-    // 这里应该调用API保存视频数据
-    console.log('保存视频:', videoForm);
+  const handleSaveVideo = async () => {
+    const method = editingVideo ? 'PUT' : 'POST';
+    const url = editingVideo ? `/api/videos/${editingVideo.id}` : '/api/videos';
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(videoForm),
+    });
     setShowVideoForm(false);
     resetVideoForm();
+    window.location.reload();
   };
 
   const handleSaveSettings = () => {
@@ -105,15 +119,17 @@ const AdminPage: React.FC = () => {
     setShowVideoForm(true);
   };
 
-  const handleDeleteCourse = (courseId: number) => {
+  const handleDeleteCourse = async (courseId: number) => {
     if (confirm('确定要删除这个课程吗？')) {
-      console.log('删除课程:', courseId);
+      await fetch(`/api/courses/${courseId}`, { method: 'DELETE' });
+      window.location.reload();
     }
   };
 
-  const handleDeleteVideo = (videoId: number) => {
+  const handleDeleteVideo = async (videoId: number) => {
     if (confirm('确定要删除这个视频吗？')) {
-      console.log('删除视频:', videoId);
+      await fetch(`/api/videos/${videoId}`, { method: 'DELETE' });
+      window.location.reload();
     }
   };
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -20,15 +20,12 @@ const HomePage: React.FC = () => {
     isPlaying,
     isMuted,
     showSubtitles,
-    currentTime,
-    duration,
     isLoading,
     hasAudioPermission,
     requestAudioPermission,
     togglePlay,
     toggleMute,
     toggleSubtitles,
-    seekTo,
   } = useVideoPlayer();
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -94,15 +91,6 @@ const HomePage: React.FC = () => {
   // 移除自动切换逻辑，保持视频循环播放
   // 只有用户交互时才切换视频，符合TikTok的播放逻辑
 
-  // 格式化时间
-  const formatTime = (time: number) => {
-    const minutes = Math.floor(time / 60);
-    const seconds = Math.floor(time % 60);
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  // 计算进度百分比
-  const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   // 首次播放权限请求
   const handleFirstPlay = () => {
@@ -192,7 +180,7 @@ const HomePage: React.FC = () => {
       </div>
 
       {/* 右侧操作栏 */}
-      <div className="absolute right-4 bottom-32 z-20 flex flex-col space-y-6">
+      <div className="absolute right-4 bottom-24 z-20 flex flex-col space-y-6">
         {/* 课程头像 */}
         <button
           onClick={() => navigate(`/course/${currentItem.course.tag}`)}
@@ -247,7 +235,7 @@ const HomePage: React.FC = () => {
       </div>
 
       {/* 左下角课程信息 */}
-      <div className="absolute left-4 bottom-32 z-20 max-w-[60%]">
+      <div className="absolute left-4 bottom-24 z-20 max-w-[60%]">
         <h3 className="text-white text-lg font-semibold mb-2">
           {currentItem.course.name}
         </h3>
@@ -256,19 +244,6 @@ const HomePage: React.FC = () => {
         </p>
       </div>
 
-      {/* 底部进度条 */}
-      <div className="absolute bottom-20 left-4 right-20 z-20">
-        <div className="flex items-center space-x-2 text-white text-xs">
-          <span>{formatTime(currentTime)}</span>
-          <div className="flex-1 h-1 bg-white/30 rounded-full overflow-hidden">
-            <div 
-              className="h-full bg-white transition-all duration-300"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          <span>{formatTime(duration)}</span>
-        </div>
-      </div>
 
       {/* 右下角声音状态 */}
       <div className="absolute bottom-20 right-4 z-20">
@@ -303,7 +278,7 @@ const HomePage: React.FC = () => {
       {/* 中间点击区域 - 专门处理播放暂停 */}
       {hasAudioPermission && (
         <div 
-          className="absolute top-20 left-4 bottom-32 right-20 z-10 cursor-pointer"
+          className="absolute top-20 left-4 bottom-24 right-20 z-10 cursor-pointer"
           onClick={handleTogglePlay}
           style={{ 
             // 确保不影响其他元素，透明点击区域

--- a/src/components/VideoPlayPage.tsx
+++ b/src/components/VideoPlayPage.tsx
@@ -17,15 +17,12 @@ const VideoPlayPage: React.FC = () => {
     isPlaying,
     isMuted,
     showSubtitles,
-    currentTime,
-    duration,
     isLoading,
     hasAudioPermission,
     requestAudioPermission,
     togglePlay,
     toggleMute,
     toggleSubtitles,
-    seekTo,
   } = useVideoPlayer();
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -76,15 +73,6 @@ const VideoPlayPage: React.FC = () => {
   // 移除自动切换逻辑，保持视频循环播放
   // 只有用户交互时才切换视频，符合TikTok的播放逻辑
 
-  // 格式化时间
-  const formatTime = (time: number) => {
-    const minutes = Math.floor(time / 60);
-    const seconds = Math.floor(time % 60);
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  // 计算进度百分比
-  const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   // 首次播放权限请求
   const handleFirstPlay = () => {
@@ -159,7 +147,7 @@ const VideoPlayPage: React.FC = () => {
       </div>
 
       {/* 右侧操作栏 */}
-      <div className="absolute right-4 bottom-32 z-20 flex flex-col space-y-6">
+      <div className="absolute right-4 bottom-24 z-20 flex flex-col space-y-6">
         {/* 课程头像 */}
         <button
           onClick={() => navigate(`/course/${course.tag}`)}
@@ -214,7 +202,7 @@ const VideoPlayPage: React.FC = () => {
       </div>
 
       {/* 左下角视频信息 */}
-      <div className="absolute left-4 bottom-32 z-20 max-w-[60%]">
+      <div className="absolute left-4 bottom-24 z-20 max-w-[60%]">
         <h3 className="text-white text-lg font-semibold mb-1">
           {course.name} - 第{currentVideo.sequence}集
         </h3>
@@ -223,19 +211,6 @@ const VideoPlayPage: React.FC = () => {
         </p>
       </div>
 
-      {/* 底部进度条 */}
-      <div className="absolute bottom-20 left-4 right-20 z-20">
-        <div className="flex items-center space-x-2 text-white text-xs">
-          <span>{formatTime(currentTime)}</span>
-          <div className="flex-1 h-1 bg-white/30 rounded-full overflow-hidden">
-            <div 
-              className="h-full bg-white transition-all duration-300"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          <span>{formatTime(duration)}</span>
-        </div>
-      </div>
 
       {/* 右下角声音状态 */}
       <div className="absolute bottom-20 right-4 z-20">
@@ -270,7 +245,7 @@ const VideoPlayPage: React.FC = () => {
       {/* 中间点击区域 - 专门处理播放暂停 */}
       {hasAudioPermission && (
         <div 
-          className="absolute top-20 left-4 bottom-32 right-20 z-10 cursor-pointer"
+          className="absolute top-20 left-4 bottom-24 right-20 z-10 cursor-pointer"
           onClick={handleTogglePlay}
           style={{ 
             // 确保不影响其他元素，透明点击区域

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -12,8 +12,8 @@ export const useData = () => {
       try {
         setLoading(true);
         const [coursesResponse, videosResponse] = await Promise.all([
-          fetch('/data/courses.json'),
-          fetch('/data/videos.json'),
+          fetch('/api/courses').catch(() => fetch('/data/courses.json')),
+          fetch('/api/videos').catch(() => fetch('/data/videos.json')),
         ]);
 
         if (!coursesResponse.ok || !videosResponse.ok) {


### PR DESCRIPTION
## Summary
- add simple Express server for reading/writing data JSON files
- fetch data from new API with fallback to static JSON
- allow admin page to persist changes via API
- remove video progress bar and adjust layout spacing for TikTok style

## Testing
- `npm run lint` *(fails: GET https://registry.npmjs.org/express: Forbidden)*
- `npm run build` *(fails: GET https://registry.npmjs.org/express: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6865229b5228832dac6e8abf41b6a5b3